### PR TITLE
Add CellArray._nonempty_domain at construction time

### DIFF
--- a/src/cellarr_array/CellArray.py
+++ b/src/cellarr_array/CellArray.py
@@ -70,6 +70,7 @@ class CellArray(ABC):
         self._ndim = None
         self._dim_names = None
         self._attr_names = None
+        self._nonempty_domain = None
 
         if validate:
             self._validate(attr=attr)


### PR DESCRIPTION
Otherwise, the check  `_nonempty_domain is None` will fail with attribute error