### PR TITLE
Add support for ellipsis in indexing

### DIFF
--- a/src/cellarr_array/CellArray.py
+++ b/src/cellarr_array/CellArray.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+
 try:
     from types import EllipsisType
 except ImportError:

--- a/src/cellarr_array/CellArray.py
+++ b/src/cellarr_array/CellArray.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from types import EllipsisType
 from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np
@@ -160,7 +161,7 @@ class CellArray(ABC):
         finally:
             array.close()
 
-    def __getitem__(self, key: Union[slice, Tuple[Union[slice, List[int]], ...]]):
+    def __getitem__(self, key: Union[slice, EllipsisType, Tuple[Union[slice, List[int]], ...], EllipsisType]):
         """Get item implementation that routes to either direct slicing or multi_index
         based on the type of indices provided.
 
@@ -177,16 +178,22 @@ class CellArray(ABC):
         # Normalize all indices
         normalized_key = tuple(SliceHelper.normalize_index(idx, self.shape[i]) for i, idx in enumerate(key))
 
+        num_ellipsis = sum(isinstance(i, EllipsisType) for i in normalized_key)
+        if num_ellipsis > 1:
+            raise IndexError(f"Found more than 1 Ellipsis (...) in key: {normalized_key}")
+
         # Check if we can use direct slicing
-        use_direct = all(isinstance(idx, slice) for idx in normalized_key)
+        use_direct = all(isinstance(idx, (slice, EllipsisType)) for idx in normalized_key)
 
         if use_direct:
             return self._direct_slice(normalized_key)
         else:
+            if num_ellipsis > 0:
+                raise IndexError(f"tiledb does not support ellipsis in multi-index access: {normalized_key}")
             return self._multi_index(normalized_key)
 
     @abstractmethod
-    def _direct_slice(self, key: Tuple[slice, ...]) -> np.ndarray:
+    def _direct_slice(self, key: Tuple[Union[slice, EllipsisType], ...]) -> np.ndarray:
         """Implementation for direct slicing."""
         pass
 

--- a/src/cellarr_array/CellArray.py
+++ b/src/cellarr_array/CellArray.py
@@ -1,6 +1,10 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from types import EllipsisType
+try:
+    from types import EllipsisType
+except ImportError:
+    # TODO: This is required for Python <3.10. Remove once Python 3.9 reaches EOL in October 2025
+    EllipsisType = type(...)
 from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np

--- a/src/cellarr_array/DenseCellArray.py
+++ b/src/cellarr_array/DenseCellArray.py
@@ -1,3 +1,4 @@
+from types import EllipsisType
 from typing import List, Tuple, Union
 
 import numpy as np
@@ -13,7 +14,7 @@ __license__ = "MIT"
 class DenseCellArray(CellArray):
     """Implementation for dense TileDB arrays."""
 
-    def _direct_slice(self, key: Tuple[slice, ...]) -> np.ndarray:
+    def _direct_slice(self, key: Tuple[Union[slice, EllipsisType], ...]) -> np.ndarray:
         """Implementation for direct slicing of dense arrays.
 
         Args:

--- a/src/cellarr_array/DenseCellArray.py
+++ b/src/cellarr_array/DenseCellArray.py
@@ -1,4 +1,8 @@
-from types import EllipsisType
+try:
+    from types import EllipsisType
+except ImportError:
+    # TODO: This is required for Python <3.10. Remove once Python 3.9 reaches EOL in October 2025
+    EllipsisType = type(...)
 from typing import List, Tuple, Union
 
 import numpy as np

--- a/src/cellarr_array/SparseCellArray.py
+++ b/src/cellarr_array/SparseCellArray.py
@@ -1,3 +1,4 @@
+from types import EllipsisType
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -118,7 +119,7 @@ class SparseCellArray(CellArray):
 
         return sliced[key]
 
-    def _direct_slice(self, key: Tuple[slice, ...]) -> Union[np.ndarray, sparse.coo_matrix]:
+    def _direct_slice(self, key: Tuple[Union[slice, EllipsisType], ...]) -> Union[np.ndarray, sparse.coo_matrix]:
         """Implementation for direct slicing of sparse arrays."""
         with self.open_array(mode="r") as array:
             result = array[key]

--- a/src/cellarr_array/SparseCellArray.py
+++ b/src/cellarr_array/SparseCellArray.py
@@ -1,4 +1,8 @@
-from types import EllipsisType
+try:
+    from types import EllipsisType
+except ImportError:
+    # TODO: This is required for Python <3.10. Remove once Python 3.9 reaches EOL in October 2025
+    EllipsisType = type(...)
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np

--- a/src/cellarr_array/helpers.py
+++ b/src/cellarr_array/helpers.py
@@ -1,3 +1,4 @@
+from types import EllipsisType
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -150,8 +151,11 @@ class SliceHelper:
         return None
 
     @staticmethod
-    def normalize_index(idx: Union[int, slice, List[int]], dim_size: int) -> Union[slice, List[int]]:
+    def normalize_index(idx: Union[int, slice, List[int]], dim_size: int) -> Union[slice, List[int], EllipsisType]:
         """Normalize index to handle negative indices and ensure consistency."""
+
+        if isinstance(idx, EllipsisType):
+            return idx
 
         # Convert ranges to slices
         if isinstance(idx, range):

--- a/src/cellarr_array/helpers.py
+++ b/src/cellarr_array/helpers.py
@@ -1,4 +1,8 @@
-from types import EllipsisType
+try:
+    from types import EllipsisType
+except ImportError:
+    # TODO: This is required for Python <3.10. Remove once Python 3.9 reaches EOL in October 2025
+    EllipsisType = type(...)
 from typing import List, Optional, Tuple, Union
 
 import numpy as np

--- a/tests/test_dense.py
+++ b/tests/test_dense.py
@@ -84,6 +84,11 @@ def test_1d_slicing(sample_dense_array_1d):
     result = sample_dense_array_1d[-10:]
     np.testing.assert_array_almost_equal(result, data[-10:])
 
+    # Ellipsis
+    result = sample_dense_array_1d[...]
+    actual = data[...]
+    np.testing.assert_array_almost_equal(result, actual), f"{actual} != {result}"
+
 
 def test_2d_slicing(sample_dense_array_2d):
     data = np.random.random((100, 50)).astype(np.float32)
@@ -104,6 +109,18 @@ def test_2d_slicing(sample_dense_array_2d):
     # Negative indices
     result = sample_dense_array_2d[-10:, -5:]
     np.testing.assert_array_almost_equal(result, data[-10:, -5:])
+
+    # Ellipsis
+    result = sample_dense_array_2d[..., :1]
+    np.testing.assert_array_almost_equal(result, data[..., :1])
+    result = sample_dense_array_2d[..., :]
+    np.testing.assert_array_almost_equal(result, data[..., :])
+    result = sample_dense_array_2d[-1:, ...]
+    np.testing.assert_array_almost_equal(result, data[-1:, ...])
+    with pytest.raises(IndexError):
+        _ = sample_dense_array_2d[..., ...]
+    with pytest.raises(IndexError):
+        _ = sample_dense_array_2d[[0, 3], ...]
 
 
 def test_multi_index_access(sample_dense_array_2d):

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -98,6 +98,11 @@ def test_coo_output(sample_sparse_array_2d):
     assert sparse.isspmatrix_csr(result)
     np.testing.assert_array_almost_equal(result.toarray(), data.toarray())
 
+    # Test full slice with ellipsis
+    result = array_coo[0:10, ...]
+    assert sparse.isspmatrix_csr(result)
+    np.testing.assert_array_almost_equal(result.toarray(), data.toarray())
+
     # Test partial slice
     data_csr = data.tocsr()
     result = array_coo[2:5, 10:20]


### PR DESCRIPTION
tiledb supports ellipsis for direct indexing, so we should also include that in `__getitem__`. Otherwise,
```python
carray: CellArray = ...
carray[1:3]
```
is possible, but
```python
carray[..., 1:3]
```
is not